### PR TITLE
Correctly throw errors when entry creation from XML fails

### DIFF
--- a/lib/middle_english_dictionary.rb
+++ b/lib/middle_english_dictionary.rb
@@ -2,3 +2,13 @@ require "middle_english_dictionary/version"
 require "middle_english_dictionary/entry"
 require 'middle_english_dictionary/collection/oed_link_set'
 require 'middle_english_dictionary/collection/entry_set'
+
+# module MiddleEnglishDictionary
+#
+#   def self.logger(newlogger)
+#     if newlogger
+#       @logger = newlogger
+#     end
+#     @logger
+#   end
+# end

--- a/lib/middle_english_dictionary/entry/class_methods.rb
+++ b/lib/middle_english_dictionary/entry/class_methods.rb
@@ -1,14 +1,21 @@
+require "middle_english_dictionary/errors"
+
 module MiddleEnglishDictionary
   class Entry
     module ClassMethods
       def new_from_xml(xml, source: nil)
+        node = Nokogiri::XML(xml) {|conf| conf.strict}
         new_from_nokonode(Nokogiri::XML(xml), source: source)
+      rescue Nokogiri::XML::SyntaxError => e
+        raise MiddleEnglishDictionary::InvalidXML.new("Invalid XML in #{source}: #{e.message}")
       end
 
+
       def new_from_xml_file(filename)
+        raise MiddleEnglishDictionary::FileNotFound.new("File '#{filename}' not found") unless File.exists?(filename)
+        raise MiddleEnglishDictionary::FileEmpty.new("File '#{filename}' is empty") if File.empty?(filename)
         new_from_xml(File.open(filename, 'r:utf-8').read, source: filename)
       end
     end
-
   end
 end

--- a/lib/middle_english_dictionary/entry/sense.rb
+++ b/lib/middle_english_dictionary/entry/sense.rb
@@ -31,7 +31,7 @@ module MiddleEnglishDictionary
       end
 
       def get_discipline_usages(nokonode)
-        nokonode.xpath('//DEF/USG[@TYPE="FIELD"]').map {|n| n.attr('EXPAN')}.map(&:capitalize).uniq
+        nokonode.xpath('//DEF/USG[@TYPE="FIELD"]/@EXPAN').map {|n| n.attr('EXPAN')}.map(&:capitalize).uniq
       end
 
     end

--- a/lib/middle_english_dictionary/entry/sense.rb
+++ b/lib/middle_english_dictionary/entry/sense.rb
@@ -31,7 +31,7 @@ module MiddleEnglishDictionary
       end
 
       def get_discipline_usages(nokonode)
-        nokonode.xpath('//DEF/USG[@TYPE="FIELD"]/@EXPAN').map {|n| n.attr('EXPAN')}.map(&:capitalize).uniq
+        nokonode.xpath('//DEF/USG[@TYPE="FIELD"]/@EXPAN').map(&:value).map(&:capitalize).uniq
       end
 
     end

--- a/lib/middle_english_dictionary/errors.rb
+++ b/lib/middle_english_dictionary/errors.rb
@@ -1,0 +1,7 @@
+module MiddleEnglishDictionary
+
+  class FileNotFound < RuntimeError; end
+  class FileEmpty < RuntimeError; end
+  class InvalidXML < RuntimeError; end
+
+end


### PR DESCRIPTION
    Some files are showing up empty or invalid. These are caught
    with new exception classes (in `lib/middle_english_dictionary/errors.rb`)
    so the can be handled by the calling application.